### PR TITLE
fix for instances with no tags

### DIFF
--- a/smsh/target/__init__.py
+++ b/smsh/target/__init__.py
@@ -50,4 +50,4 @@ def create(target):
 
         return Instance(instance_id=instance_id)
     else:
-        raise NotImplementedError("{} did not match either an instance ID or instance IP pattern")
+        raise NotImplementedError("{} did not match either an instance ID or instance IP pattern".format(target))

--- a/smsh/target/target.py
+++ b/smsh/target/target.py
@@ -40,10 +40,11 @@ class Target(object):
         self.instance = instance
 
         self.name = None
-        for tag in self.instance["Tags"]:
-            if tag["Key"] == "Name":
-                self.name = tag["Value"]
-                break
+        if ("Tags" in self.instance):
+            for tag in self.instance["Tags"]:
+                if tag["Key"] == "Name":
+                    self.name = tag["Value"]
+                    break
         if not self.name:
             self.name = instance_id
 


### PR DESCRIPTION
Trying to connect to an instance with no tags results in an error, this PR should fix it:

> File "/usr/local/bin/smsh", line 11, in <module>
    load_entry_point('smsh==0.0.1', 'console_scripts', 'smsh')()
  File "/usr/local/lib/python3.6/site-packages/smsh-0.0.1-py3.6.egg/smsh/__main__.py", line 45, in main
  File "/usr/local/lib/python3.6/site-packages/smsh-0.0.1-py3.6.egg/smsh/target/__init__.py", line 37, in create
  File "/usr/local/lib/python3.6/site-packages/smsh-0.0.1-py3.6.egg/smsh/target/instance.py", line 10, in __init__
  File "/usr/local/lib/python3.6/site-packages/smsh-0.0.1-py3.6.egg/smsh/target/target.py", line 43, in __init__
KeyError: 'Tags'